### PR TITLE
chore: add autonomous AI test suites for backend services

### DIFF
--- a/suite-manager/backend/test/backup-inventory-service.test.cjs
+++ b/suite-manager/backend/test/backup-inventory-service.test.cjs
@@ -4,73 +4,39 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
+const TEMP_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'backup-inventory-'));
 const servicePath = require.resolve('../src/backups/backup-inventory-service.cjs');
 
-const dependencyRequests = {
-  manifest: '../apps/package-manifest.cjs',
-  contracts: '../apps/package-contracts.cjs',
-  suite: '../state/suite-manager-store.cjs',
-  persistent: '../../../../infrastructure/persistent-state.cjs',
-};
+const { BackupInventoryService, DEFAULT_CADDY_FILES, DEFAULT_HTTPS_SECRET_PATH, HOMEPAGE_CONFIG_FILES, uniqueVolumesFor } = require(servicePath);
+const { digestAppPackage } = require('../src/apps/package-contracts.cjs');
 
-function withService(overrides, callback) {
-  const resolved = {};
-  for (const [name, request] of Object.entries(dependencyRequests)) {
-    resolved[name] = require.resolve(request, { paths: [path.dirname(servicePath)] });
-  }
-
-  const saved = {};
-  for (const [name, resolvedPath] of Object.entries(resolved)) {
-    saved[name] = require.cache[resolvedPath];
-  }
-
-  const defaults = {
-    manifest: {
-      readAppPackageManifest() {
-        throw new Error('readAppPackageManifest() was called without a test stub');
-      },
-    },
-    contracts: {
-      digestAppPackage() {
-        return 'digest';
-      },
-    },
-    suite: {
-      DATABASE_FILENAME: 'mos.db',
-    },
-    persistent: {
-      appVolumeName(packageId, volumeName) {
-        return `${packageId}-${volumeName}`;
-      },
-    },
+function setupSnapshot(manifestObj) {
+  const snapshotPath = fs.mkdtempSync(path.join(os.tmpdir(), 'mos-snap-'));
+  
+  // Create a valid default manifest that passes all schema validation rules
+  const defaultManifest = {
+    manifestVersion: 1,
+    name: 'Test App',
+    minimumMosVersion: '1.0.0',
+    summary: 'A test app',
+    category: 'utilities',
+    health: { type: 'http', url: 'http://app/' },
+    resources: { services: { main: { image: 'test-image' } } },
+    version: '1.0.0'
   };
-
-  for (const name of Object.keys(dependencyRequests)) {
-    const resolvedPath = resolved[name];
-    require.cache[resolvedPath] = {
-      id: resolvedPath,
-      filename: resolvedPath,
-      loaded: true,
-      exports: {
-        ...defaults[name],
-        ...(overrides[name] || {}),
-      },
-    };
-  }
-
-  delete require.cache[servicePath];
-  const service = require(servicePath);
-
-  try {
-    return callback(service);
-  } finally {
-    delete require.cache[servicePath];
-    for (const name of Object.keys(dependencyRequests)) {
-      const resolvedPath = resolved[name];
-      delete require.cache[resolvedPath];
-      if (saved[name]) require.cache[resolvedPath] = saved[name];
-    }
-  }
+  
+  // Merge the provided manifestObj over the defaults
+  const fullManifest = {
+    ...defaultManifest,
+    ...manifestObj,
+    // Deep merge resources to avoid wiping out the valid default if resources is partially specified
+    resources: manifestObj?.resources || defaultManifest.resources
+  };
+  
+  fs.writeFileSync(path.join(snapshotPath, 'manifest.json'), JSON.stringify(fullManifest));
+  fs.writeFileSync(path.join(snapshotPath, 'Dockerfile'), ''); // write empty dockerfile so validation passes
+  const digest = digestAppPackage(snapshotPath);
+  return { snapshotPath, digest };
 }
 
 function makeInstance(overrides = {}) {
@@ -101,69 +67,57 @@ function makeStore(instances, relationships = []) {
 }
 
 test('exports the expected default backup inventory constants', () => {
-  withService({}, (module) => {
-    assert.deepEqual(module.DEFAULT_CADDY_FILES, [
-      '/etc/caddy/Caddyfile',
-      '/etc/caddy/mos-homepage-routes.caddy',
-      '/etc/caddy/mos-app-routes.caddy',
-    ]);
-    assert.equal(module.DEFAULT_HTTPS_SECRET_PATH, '/etc/mos/secrets/caddy-cloudflare.env');
-    assert.deepEqual(module.HOMEPAGE_CONFIG_FILES, [
-      'services.template.yaml',
-      'bookmarks.yaml',
-      'settings.yaml',
-      'widgets.yaml',
-      'custom.css',
-      'custom.js',
-      'images',
-    ]);
-  });
+  assert.deepEqual(DEFAULT_CADDY_FILES, [
+    '/etc/caddy/Caddyfile',
+    '/etc/caddy/mos-homepage-routes.caddy',
+    '/etc/caddy/mos-app-routes.caddy',
+  ]);
+  assert.equal(DEFAULT_HTTPS_SECRET_PATH, '/etc/mos/secrets/caddy-cloudflare.env');
+  assert.deepEqual(HOMEPAGE_CONFIG_FILES, [
+    'services.template.yaml',
+    'bookmarks.yaml',
+    'settings.yaml',
+    'widgets.yaml',
+    'custom.css',
+    'custom.js',
+    'images',
+  ]);
 });
 
 test('uniqueVolumesFor deduplicates volumes and sorts by docker volume name', () => {
-  withService(
-    { persistent: { appVolumeName: (pkg, volume) => `${pkg}:${volume}` } },
-    ({ uniqueVolumesFor }) => {
-      const manifest = {
-        id: 'pkg-a',
-        resources: {
-          services: {
-            api: { volumes: ['data:/var/data', ' logs :/var/logs'] },
-            worker: { volumes: ['data:/var/data', 'cache:/var/cache'] },
-          },
-        },
-      };
-
-      assert.deepEqual(uniqueVolumesFor(manifest), [
-        { declaredName: 'cache', dockerVolume: 'pkg-a:cache', backupClass: 'data', requiredOnRestore: true },
-        { declaredName: 'data', dockerVolume: 'pkg-a:data', backupClass: 'data', requiredOnRestore: true },
-        { declaredName: 'logs', dockerVolume: 'pkg-a:logs', backupClass: 'data', requiredOnRestore: true },
-      ]);
+  const manifest = {
+    id: 'pkg-a',
+    resources: {
+      services: {
+        api: { volumes: ['data:/var/data', ' logs :/var/logs'] },
+        worker: { volumes: ['data:/var/data', 'cache:/var/cache'] },
+      },
     },
-  );
+  };
+
+  assert.deepEqual(uniqueVolumesFor(manifest), [
+    { declaredName: 'cache', dockerVolume: 'mos-app-pkg-a-cache', backupClass: 'data', requiredOnRestore: true },
+    { declaredName: 'data', dockerVolume: 'mos-app-pkg-a-data', backupClass: 'data', requiredOnRestore: true },
+    { declaredName: 'logs', dockerVolume: 'mos-app-pkg-a-logs', backupClass: 'data', requiredOnRestore: true },
+  ]);
 });
 
 test('uniqueVolumesFor ignores empty or malformed volume declarations', () => {
-  withService({}, ({ uniqueVolumesFor }) => {
-    const manifest = {
-      id: 'pkg-empty',
-      resources: { services: { app: { volumes: [null, '', ':', '   '] } } },
-    };
-    assert.deepEqual(uniqueVolumesFor(manifest), []);
-  });
+  const manifest = {
+    id: 'pkg-empty',
+    resources: { services: { app: { volumes: [null, '', ':', '   '] } } },
+  };
+  assert.deepEqual(uniqueVolumesFor(manifest), []);
 });
 
 test('uniqueVolumesFor handles manifests without services', () => {
-  withService({}, ({ uniqueVolumesFor }) => {
-    assert.deepEqual(uniqueVolumesFor({ id: 'no-services', resources: {} }), []);
-  });
+  assert.deepEqual(uniqueVolumesFor({ id: 'no-services', resources: {} }), []);
 });
 
 test('constructor uses MOS_STATE_ROOT when present', () => {
   const previous = process.env.MOS_STATE_ROOT;
   process.env.MOS_STATE_ROOT = '/tmp/mos-state';
   try {
-    withService({}, ({ BackupInventoryService }) => {
       const service = new BackupInventoryService({
         stateDir: '/tmp/state/suite-manager',
         store: {},
@@ -173,8 +127,7 @@ test('constructor uses MOS_STATE_ROOT when present', () => {
         service.homepageConfigRoot,
         path.join('/tmp/mos-state', 'homepage', 'config'),
       );
-    });
-  } finally {
+      } finally {
     if (previous === undefined) delete process.env.MOS_STATE_ROOT;
     else process.env.MOS_STATE_ROOT = previous;
   }
@@ -184,14 +137,12 @@ test('constructor defaults stateRoot to parent when stateDir is suite-manager', 
   const previous = process.env.MOS_STATE_ROOT;
   delete process.env.MOS_STATE_ROOT;
   try {
-    withService({}, ({ BackupInventoryService }) => {
       const service = new BackupInventoryService({
-        stateDir: '/tmp/mos/suite-manager',
+        stateDir: path.join(TEMP_ROOT, 'suite-manager'),
         store: {},
       });
-      assert.equal(service.stateRoot, '/tmp/mos');
-    });
-  } finally {
+      assert.equal(service.stateRoot, TEMP_ROOT);
+      } finally {
     if (previous === undefined) delete process.env.MOS_STATE_ROOT;
     else process.env.MOS_STATE_ROOT = previous;
   }
@@ -201,32 +152,24 @@ test('constructor resolves stateRoot to parent for non-suite-manager state dirs'
   const previous = process.env.MOS_STATE_ROOT;
   delete process.env.MOS_STATE_ROOT;
   try {
-    withService({}, ({ BackupInventoryService }) => {
       const service = new BackupInventoryService({
-        stateDir: '/tmp/mos/state-dir',
+        stateDir: path.join(TEMP_ROOT, 'state-dir'),
         store: {},
       });
-      assert.equal(service.stateRoot, '/tmp/mos');
-    });
-  } finally {
+      assert.equal(service.stateRoot, TEMP_ROOT);
+      } finally {
     if (previous === undefined) delete process.env.MOS_STATE_ROOT;
     else process.env.MOS_STATE_ROOT = previous;
   }
 });
 
 test('constructor applies default caddy and secret paths', () => {
-  withService(
-    {},
-    ({ BackupInventoryService, DEFAULT_CADDY_FILES, DEFAULT_HTTPS_SECRET_PATH }) => {
-      const service = new BackupInventoryService({ stateDir: '/tmp/mos', store: {} });
-      assert.deepEqual(service.caddyFiles, DEFAULT_CADDY_FILES);
-      assert.equal(service.httpsSecretPath, DEFAULT_HTTPS_SECRET_PATH);
-    },
-  );
+  const service = new BackupInventoryService({ stateDir: TEMP_ROOT, store: {} });
+  assert.deepEqual(service.caddyFiles, DEFAULT_CADDY_FILES);
+  assert.equal(service.httpsSecretPath, DEFAULT_HTTPS_SECRET_PATH);
 });
 
 test('inventory summarizes an empty store', () => {
-  withService({}, ({ BackupInventoryService }) => {
     const service = new BackupInventoryService({
       stateDir: '/tmp/empty-state',
       store: makeStore([]),
@@ -250,7 +193,6 @@ test('inventory summarizes an empty store', () => {
     assert.equal(typeof result.checkedAt, 'string');
     assert.equal(Number.isNaN(Date.parse(result.checkedAt)), false);
   });
-});
 
 test('inventory reports missing snapshot warnings for uninstalled snapshot states', () => {
   const instance = makeInstance({
@@ -260,7 +202,6 @@ test('inventory reports missing snapshot warnings for uninstalled snapshot state
     snapshotPath: '/does/not/exist',
   });
 
-  withService({}, ({ BackupInventoryService }) => {
     const service = new BackupInventoryService({
       stateDir: '/tmp/state',
       store: makeStore([instance]),
@@ -278,24 +219,14 @@ test('inventory reports missing snapshot warnings for uninstalled snapshot state
     assert.equal(result.summary.warningCount, 1);
     assert.deepEqual(result.packageManifestDigests, []);
   });
-});
 
 test('inventory treats manifest read failures as invalid snapshots', () => {
   const instance = makeInstance({
     packageId: 'app-1',
     snapshotState: 'installed',
-    snapshotPath: '/snap/app-1',
+    snapshotPath: '/snap/app-1', // will fail to read since it doesn't exist
   });
 
-  withService(
-    {
-      manifest: {
-        readAppPackageManifest() {
-          throw new Error('boom');
-        },
-      },
-    },
-    ({ BackupInventoryService }) => {
       const service = new BackupInventoryService({
         stateDir: '/tmp/state',
         store: makeStore([instance]),
@@ -306,43 +237,24 @@ test('inventory treats manifest read failures as invalid snapshots', () => {
       assert.equal(result.packages[0].snapshot.verified, false);
       assert.deepEqual(result.packages[0].declaredVolumes, []);
       assert.equal(result.summary.warningCount, 1);
-    },
-  );
-});
+    });
 
 test('inventory maps a verified installed package and its declared volumes', () => {
+  const { snapshotPath, digest } = setupSnapshot({
+    id: 'app-1',
+    resources: { services: { app: { dockerfile: 'Dockerfile', internalPort: 8080, volumes: ['data:/data'] } } },
+    version: '1.0.0',
+  });
+
   const instance = makeInstance({
     packageId: 'app-1',
+    packageVersion: '1.0.0',
     manifestDigest: 'manifest-digest-1',
-    packageDigest: 'package-digest-1',
-    snapshotPath: '/snap/app-1',
+    packageDigest: digest,
+    snapshotPath,
     snapshotState: 'installed',
   });
 
-  withService(
-    {
-      manifest: {
-        readAppPackageManifest(snapshotPath) {
-          assert.equal(snapshotPath, '/snap/app-1');
-          return {
-            manifest: {
-              id: 'app-1',
-              resources: { services: { app: { volumes: ['data:/data'] } } },
-            },
-          };
-        },
-      },
-      contracts: {
-        digestAppPackage(snapshotPath) {
-          assert.equal(snapshotPath, '/snap/app-1');
-          return 'package-digest-1';
-        },
-      },
-      persistent: {
-        appVolumeName: (pkg, volume) => `${pkg}:${volume}`,
-      },
-    },
-    ({ BackupInventoryService }) => {
       const service = new BackupInventoryService({
         stateDir: '/tmp/state',
         store: makeStore([instance]),
@@ -354,7 +266,7 @@ test('inventory maps a verified installed package and its declared volumes', () 
       assert.equal(pkg.manifestPresent, true);
       assert.equal(pkg.snapshot.verified, true);
       assert.deepEqual(pkg.declaredVolumes, [
-        { declaredName: 'data', dockerVolume: 'app-1:data', backupClass: 'data', requiredOnRestore: true },
+        { declaredName: 'data', dockerVolume: 'mos-app-app-1-data', backupClass: 'data', requiredOnRestore: true },
       ]);
       assert.deepEqual(pkg.warnings, [
         'Package declares volumes but no explicit backup metadata yet.',
@@ -364,31 +276,18 @@ test('inventory maps a verified installed package and its declared volumes', () 
       assert.deepEqual(result.packageManifestDigests, [
         { digest: 'manifest-digest-1', packageId: 'app-1', version: '1.0.0' },
       ]);
-    },
-  );
-});
+    });
 
 test('inventory marks snapshot unverified when manifest id does not match package id', () => {
+  const { snapshotPath, digest } = setupSnapshot({ id: 'app-2', resources: { services: { app: { dockerfile: 'Dockerfile', internalPort: 8080 } } } });
+  
   const instance = makeInstance({
     packageId: 'app-1',
+    packageDigest: digest,
     snapshotState: 'installed',
-    snapshotPath: '/snap/app-1',
+    snapshotPath,
   });
 
-  withService(
-    {
-      manifest: {
-        readAppPackageManifest() {
-          return { manifest: { id: 'app-2', resources: { services: {} } } };
-        },
-      },
-      contracts: {
-        digestAppPackage() {
-          return 'package-digest-1';
-        },
-      },
-    },
-    ({ BackupInventoryService }) => {
       const service = new BackupInventoryService({
         stateDir: '/tmp/state',
         store: makeStore([instance]),
@@ -401,32 +300,18 @@ test('inventory marks snapshot unverified when manifest id does not match packag
       assert.deepEqual(pkg.warnings, [
         'Installed package snapshot is missing or invalid; restore compatibility cannot be guaranteed.',
       ]);
-    },
-  );
-});
+    });
 
 test('inventory marks snapshot unverified when package digest does not match', () => {
+  const { snapshotPath, digest } = setupSnapshot({ id: 'app-1', resources: { services: { app: { dockerfile: 'Dockerfile', internalPort: 8080 } } } });
+  
   const instance = makeInstance({
     packageId: 'app-1',
-    packageDigest: 'expected-digest',
+    packageDigest: 'wrong-digest',
     snapshotState: 'installed',
-    snapshotPath: '/snap/app-1',
+    snapshotPath,
   });
 
-  withService(
-    {
-      manifest: {
-        readAppPackageManifest() {
-          return { manifest: { id: 'app-1', resources: { services: {} } } };
-        },
-      },
-      contracts: {
-        digestAppPackage() {
-          return 'wrong-digest';
-        },
-      },
-    },
-    ({ BackupInventoryService }) => {
       const service = new BackupInventoryService({
         stateDir: '/tmp/state',
         store: makeStore([instance]),
@@ -438,9 +323,7 @@ test('inventory marks snapshot unverified when package digest does not match', (
       assert.deepEqual(pkg.warnings, [
         'Installed package snapshot is missing or invalid; restore compatibility cannot be guaranteed.',
       ]);
-    },
-  );
-});
+    });
 
 test('inventory aggregates relationship statuses', () => {
   const relationships = [
@@ -449,7 +332,6 @@ test('inventory aggregates relationship statuses', () => {
     { status: 'disabled' },
   ];
 
-  withService({}, ({ BackupInventoryService }) => {
     const service = new BackupInventoryService({
       stateDir: '/tmp/state',
       store: makeStore([], relationships),
@@ -466,7 +348,6 @@ test('inventory aggregates relationship statuses', () => {
     });
     assert.equal(result.summary.relationshipCount, 3);
   });
-});
 
 test('inventory reports filesystem path states for contents', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'backup-inventory-'));
@@ -480,9 +361,6 @@ test('inventory reports filesystem path states for contents', () => {
     const homepageConfigRoot = path.join(root, 'homepage', 'config');
     fs.mkdirSync(homepageConfigRoot, { recursive: true });
 
-    withService(
-      { suite: { DATABASE_FILENAME: 'suite.db' } },
-      ({ BackupInventoryService, HOMEPAGE_CONFIG_FILES }) => {
         const service = new BackupInventoryService({
           stateDir,
           homepageConfigRoot,
@@ -507,14 +385,12 @@ test('inventory reports filesystem path states for contents', () => {
         );
         assert.deepEqual(result.contents.suiteManager, {
           appSecrets: { exists: false, kind: 'missing', path: path.join(stateDir, 'app-secrets') },
-          database: { exists: false, kind: 'missing', path: path.join(stateDir, 'suite.db') },
-          databaseShm: { exists: false, kind: 'missing', path: path.join(stateDir, 'suite.db-shm') },
-          databaseWal: { exists: false, kind: 'missing', path: path.join(stateDir, 'suite.db-wal') },
+          database: { exists: false, kind: 'missing', path: path.join(stateDir, 'suite-manager.sqlite') },
+          databaseShm: { exists: false, kind: 'missing', path: path.join(stateDir, 'suite-manager.sqlite-shm') },
+          databaseWal: { exists: false, kind: 'missing', path: path.join(stateDir, 'suite-manager.sqlite-wal') },
           stateDir,
         });
-      },
-    );
-  } finally {
+        } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
 });

--- a/suite-manager/backend/test/backup-inventory-service.test.cjs
+++ b/suite-manager/backend/test/backup-inventory-service.test.cjs
@@ -1,0 +1,520 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const servicePath = require.resolve('../src/backups/backup-inventory-service.cjs');
+
+const dependencyRequests = {
+  manifest: '../apps/package-manifest.cjs',
+  contracts: '../apps/package-contracts.cjs',
+  suite: '../state/suite-manager-store.cjs',
+  persistent: '../../../../infrastructure/persistent-state.cjs',
+};
+
+function withService(overrides, callback) {
+  const resolved = {};
+  for (const [name, request] of Object.entries(dependencyRequests)) {
+    resolved[name] = require.resolve(request, { paths: [path.dirname(servicePath)] });
+  }
+
+  const saved = {};
+  for (const [name, resolvedPath] of Object.entries(resolved)) {
+    saved[name] = require.cache[resolvedPath];
+  }
+
+  const defaults = {
+    manifest: {
+      readAppPackageManifest() {
+        throw new Error('readAppPackageManifest() was called without a test stub');
+      },
+    },
+    contracts: {
+      digestAppPackage() {
+        return 'digest';
+      },
+    },
+    suite: {
+      DATABASE_FILENAME: 'mos.db',
+    },
+    persistent: {
+      appVolumeName(packageId, volumeName) {
+        return `${packageId}-${volumeName}`;
+      },
+    },
+  };
+
+  for (const name of Object.keys(dependencyRequests)) {
+    const resolvedPath = resolved[name];
+    require.cache[resolvedPath] = {
+      id: resolvedPath,
+      filename: resolvedPath,
+      loaded: true,
+      exports: {
+        ...defaults[name],
+        ...(overrides[name] || {}),
+      },
+    };
+  }
+
+  delete require.cache[servicePath];
+  const service = require(servicePath);
+
+  try {
+    return callback(service);
+  } finally {
+    delete require.cache[servicePath];
+    for (const name of Object.keys(dependencyRequests)) {
+      const resolvedPath = resolved[name];
+      delete require.cache[resolvedPath];
+      if (saved[name]) require.cache[resolvedPath] = saved[name];
+    }
+  }
+}
+
+function makeInstance(overrides = {}) {
+  return {
+    id: 'instance-1',
+    installedAt: '2025-01-01T00:00:00.000Z',
+    manifestDigest: 'manifest-digest-1',
+    packageDigest: 'package-digest-1',
+    packageId: 'app-1',
+    packageVersion: '1.0.0',
+    snapshotPath: null,
+    snapshotState: 'missing',
+    sourceKind: 'github',
+    sourcePath: 'https://github.com/acme/app',
+    sourceRepository: 'acme/app',
+    sourceRevision: 'abc123',
+    sourceTrust: 'trusted',
+    status: 'installed',
+    ...overrides,
+  };
+}
+
+function makeStore(instances, relationships = []) {
+  return {
+    getAppInstances: () => instances,
+    getAppIntegrations: () => relationships,
+  };
+}
+
+test('exports the expected default backup inventory constants', () => {
+  withService({}, (module) => {
+    assert.deepEqual(module.DEFAULT_CADDY_FILES, [
+      '/etc/caddy/Caddyfile',
+      '/etc/caddy/mos-homepage-routes.caddy',
+      '/etc/caddy/mos-app-routes.caddy',
+    ]);
+    assert.equal(module.DEFAULT_HTTPS_SECRET_PATH, '/etc/mos/secrets/caddy-cloudflare.env');
+    assert.deepEqual(module.HOMEPAGE_CONFIG_FILES, [
+      'services.template.yaml',
+      'bookmarks.yaml',
+      'settings.yaml',
+      'widgets.yaml',
+      'custom.css',
+      'custom.js',
+      'images',
+    ]);
+  });
+});
+
+test('uniqueVolumesFor deduplicates volumes and sorts by docker volume name', () => {
+  withService(
+    { persistent: { appVolumeName: (pkg, volume) => `${pkg}:${volume}` } },
+    ({ uniqueVolumesFor }) => {
+      const manifest = {
+        id: 'pkg-a',
+        resources: {
+          services: {
+            api: { volumes: ['data:/var/data', ' logs :/var/logs'] },
+            worker: { volumes: ['data:/var/data', 'cache:/var/cache'] },
+          },
+        },
+      };
+
+      assert.deepEqual(uniqueVolumesFor(manifest), [
+        { declaredName: 'cache', dockerVolume: 'pkg-a:cache', backupClass: 'data', requiredOnRestore: true },
+        { declaredName: 'data', dockerVolume: 'pkg-a:data', backupClass: 'data', requiredOnRestore: true },
+        { declaredName: 'logs', dockerVolume: 'pkg-a:logs', backupClass: 'data', requiredOnRestore: true },
+      ]);
+    },
+  );
+});
+
+test('uniqueVolumesFor ignores empty or malformed volume declarations', () => {
+  withService({}, ({ uniqueVolumesFor }) => {
+    const manifest = {
+      id: 'pkg-empty',
+      resources: { services: { app: { volumes: [null, '', ':', '   '] } } },
+    };
+    assert.deepEqual(uniqueVolumesFor(manifest), []);
+  });
+});
+
+test('uniqueVolumesFor handles manifests without services', () => {
+  withService({}, ({ uniqueVolumesFor }) => {
+    assert.deepEqual(uniqueVolumesFor({ id: 'no-services', resources: {} }), []);
+  });
+});
+
+test('constructor uses MOS_STATE_ROOT when present', () => {
+  const previous = process.env.MOS_STATE_ROOT;
+  process.env.MOS_STATE_ROOT = '/tmp/mos-state';
+  try {
+    withService({}, ({ BackupInventoryService }) => {
+      const service = new BackupInventoryService({
+        stateDir: '/tmp/state/suite-manager',
+        store: {},
+      });
+      assert.equal(service.stateRoot, '/tmp/mos-state');
+      assert.equal(
+        service.homepageConfigRoot,
+        path.join('/tmp/mos-state', 'homepage', 'config'),
+      );
+    });
+  } finally {
+    if (previous === undefined) delete process.env.MOS_STATE_ROOT;
+    else process.env.MOS_STATE_ROOT = previous;
+  }
+});
+
+test('constructor defaults stateRoot to parent when stateDir is suite-manager', () => {
+  const previous = process.env.MOS_STATE_ROOT;
+  delete process.env.MOS_STATE_ROOT;
+  try {
+    withService({}, ({ BackupInventoryService }) => {
+      const service = new BackupInventoryService({
+        stateDir: '/tmp/mos/suite-manager',
+        store: {},
+      });
+      assert.equal(service.stateRoot, '/tmp/mos');
+    });
+  } finally {
+    if (previous === undefined) delete process.env.MOS_STATE_ROOT;
+    else process.env.MOS_STATE_ROOT = previous;
+  }
+});
+
+test('constructor resolves stateRoot to parent for non-suite-manager state dirs', () => {
+  const previous = process.env.MOS_STATE_ROOT;
+  delete process.env.MOS_STATE_ROOT;
+  try {
+    withService({}, ({ BackupInventoryService }) => {
+      const service = new BackupInventoryService({
+        stateDir: '/tmp/mos/state-dir',
+        store: {},
+      });
+      assert.equal(service.stateRoot, '/tmp/mos');
+    });
+  } finally {
+    if (previous === undefined) delete process.env.MOS_STATE_ROOT;
+    else process.env.MOS_STATE_ROOT = previous;
+  }
+});
+
+test('constructor applies default caddy and secret paths', () => {
+  withService(
+    {},
+    ({ BackupInventoryService, DEFAULT_CADDY_FILES, DEFAULT_HTTPS_SECRET_PATH }) => {
+      const service = new BackupInventoryService({ stateDir: '/tmp/mos', store: {} });
+      assert.deepEqual(service.caddyFiles, DEFAULT_CADDY_FILES);
+      assert.equal(service.httpsSecretPath, DEFAULT_HTTPS_SECRET_PATH);
+    },
+  );
+});
+
+test('inventory summarizes an empty store', () => {
+  withService({}, ({ BackupInventoryService }) => {
+    const service = new BackupInventoryService({
+      stateDir: '/tmp/empty-state',
+      store: makeStore([]),
+    });
+    const result = service.inventory();
+
+    assert.equal(result.summary.appCount, 0);
+    assert.equal(result.summary.declaredVolumeCount, 0);
+    assert.equal(result.summary.relationshipCount, 0);
+    assert.equal(result.summary.warningCount, 0);
+    assert.deepEqual(result.packages, []);
+    assert.deepEqual(result.warnings, []);
+    assert.deepEqual(result.relationships, { active: 0, count: 0, statuses: [] });
+    assert.deepEqual(result.packageManifestDigests, []);
+    assert.deepEqual(result.actions, {
+      backupEnabled: false,
+      backupLabel: 'Back up everything',
+      backupReason: 'MOS backup inventory is ready, but archive and restore jobs wait for a MOS backup agent.',
+      restoreEnabled: false,
+    });
+    assert.equal(typeof result.checkedAt, 'string');
+    assert.equal(Number.isNaN(Date.parse(result.checkedAt)), false);
+  });
+});
+
+test('inventory reports missing snapshot warnings for uninstalled snapshot states', () => {
+  const instance = makeInstance({
+    id: 'inst-1',
+    packageId: 'app-1',
+    snapshotState: 'missing',
+    snapshotPath: '/does/not/exist',
+  });
+
+  withService({}, ({ BackupInventoryService }) => {
+    const service = new BackupInventoryService({
+      stateDir: '/tmp/state',
+      store: makeStore([instance]),
+    });
+    const result = service.inventory();
+
+    assert.equal(result.packages.length, 1);
+    const pkg = result.packages[0];
+    assert.equal(pkg.manifestPresent, false);
+    assert.equal(pkg.snapshot.verified, false);
+    assert.deepEqual(pkg.declaredVolumes, []);
+    assert.deepEqual(pkg.warnings, [
+      'Installed package snapshot is missing or invalid; restore compatibility cannot be guaranteed.',
+    ]);
+    assert.equal(result.summary.warningCount, 1);
+    assert.deepEqual(result.packageManifestDigests, []);
+  });
+});
+
+test('inventory treats manifest read failures as invalid snapshots', () => {
+  const instance = makeInstance({
+    packageId: 'app-1',
+    snapshotState: 'installed',
+    snapshotPath: '/snap/app-1',
+  });
+
+  withService(
+    {
+      manifest: {
+        readAppPackageManifest() {
+          throw new Error('boom');
+        },
+      },
+    },
+    ({ BackupInventoryService }) => {
+      const service = new BackupInventoryService({
+        stateDir: '/tmp/state',
+        store: makeStore([instance]),
+      });
+      const result = service.inventory();
+
+      assert.equal(result.packages[0].manifestPresent, false);
+      assert.equal(result.packages[0].snapshot.verified, false);
+      assert.deepEqual(result.packages[0].declaredVolumes, []);
+      assert.equal(result.summary.warningCount, 1);
+    },
+  );
+});
+
+test('inventory maps a verified installed package and its declared volumes', () => {
+  const instance = makeInstance({
+    packageId: 'app-1',
+    manifestDigest: 'manifest-digest-1',
+    packageDigest: 'package-digest-1',
+    snapshotPath: '/snap/app-1',
+    snapshotState: 'installed',
+  });
+
+  withService(
+    {
+      manifest: {
+        readAppPackageManifest(snapshotPath) {
+          assert.equal(snapshotPath, '/snap/app-1');
+          return {
+            manifest: {
+              id: 'app-1',
+              resources: { services: { app: { volumes: ['data:/data'] } } },
+            },
+          };
+        },
+      },
+      contracts: {
+        digestAppPackage(snapshotPath) {
+          assert.equal(snapshotPath, '/snap/app-1');
+          return 'package-digest-1';
+        },
+      },
+      persistent: {
+        appVolumeName: (pkg, volume) => `${pkg}:${volume}`,
+      },
+    },
+    ({ BackupInventoryService }) => {
+      const service = new BackupInventoryService({
+        stateDir: '/tmp/state',
+        store: makeStore([instance]),
+      });
+      const result = service.inventory();
+
+      assert.equal(result.packages.length, 1);
+      const pkg = result.packages[0];
+      assert.equal(pkg.manifestPresent, true);
+      assert.equal(pkg.snapshot.verified, true);
+      assert.deepEqual(pkg.declaredVolumes, [
+        { declaredName: 'data', dockerVolume: 'app-1:data', backupClass: 'data', requiredOnRestore: true },
+      ]);
+      assert.deepEqual(pkg.warnings, [
+        'Package declares volumes but no explicit backup metadata yet.',
+      ]);
+      assert.equal(result.summary.declaredVolumeCount, 1);
+      assert.equal(result.summary.warningCount, 1);
+      assert.deepEqual(result.packageManifestDigests, [
+        { digest: 'manifest-digest-1', packageId: 'app-1', version: '1.0.0' },
+      ]);
+    },
+  );
+});
+
+test('inventory marks snapshot unverified when manifest id does not match package id', () => {
+  const instance = makeInstance({
+    packageId: 'app-1',
+    snapshotState: 'installed',
+    snapshotPath: '/snap/app-1',
+  });
+
+  withService(
+    {
+      manifest: {
+        readAppPackageManifest() {
+          return { manifest: { id: 'app-2', resources: { services: {} } } };
+        },
+      },
+      contracts: {
+        digestAppPackage() {
+          return 'package-digest-1';
+        },
+      },
+    },
+    ({ BackupInventoryService }) => {
+      const service = new BackupInventoryService({
+        stateDir: '/tmp/state',
+        store: makeStore([instance]),
+      });
+      const pkg = service.inventory().packages[0];
+
+      assert.equal(pkg.manifestPresent, true);
+      assert.equal(pkg.snapshot.verified, false);
+      assert.deepEqual(pkg.declaredVolumes, []);
+      assert.deepEqual(pkg.warnings, [
+        'Installed package snapshot is missing or invalid; restore compatibility cannot be guaranteed.',
+      ]);
+    },
+  );
+});
+
+test('inventory marks snapshot unverified when package digest does not match', () => {
+  const instance = makeInstance({
+    packageId: 'app-1',
+    packageDigest: 'expected-digest',
+    snapshotState: 'installed',
+    snapshotPath: '/snap/app-1',
+  });
+
+  withService(
+    {
+      manifest: {
+        readAppPackageManifest() {
+          return { manifest: { id: 'app-1', resources: { services: {} } } };
+        },
+      },
+      contracts: {
+        digestAppPackage() {
+          return 'wrong-digest';
+        },
+      },
+    },
+    ({ BackupInventoryService }) => {
+      const service = new BackupInventoryService({
+        stateDir: '/tmp/state',
+        store: makeStore([instance]),
+      });
+      const pkg = service.inventory().packages[0];
+
+      assert.equal(pkg.manifestPresent, true);
+      assert.equal(pkg.snapshot.verified, false);
+      assert.deepEqual(pkg.warnings, [
+        'Installed package snapshot is missing or invalid; restore compatibility cannot be guaranteed.',
+      ]);
+    },
+  );
+});
+
+test('inventory aggregates relationship statuses', () => {
+  const relationships = [
+    { status: 'active' },
+    { status: 'active' },
+    { status: 'disabled' },
+  ];
+
+  withService({}, ({ BackupInventoryService }) => {
+    const service = new BackupInventoryService({
+      stateDir: '/tmp/state',
+      store: makeStore([], relationships),
+    });
+    const result = service.inventory();
+
+    assert.deepEqual(result.relationships, {
+      active: 2,
+      count: 3,
+      statuses: [
+        { count: 2, status: 'active' },
+        { count: 1, status: 'disabled' },
+      ],
+    });
+    assert.equal(result.summary.relationshipCount, 3);
+  });
+});
+
+test('inventory reports filesystem path states for contents', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'backup-inventory-'));
+  try {
+    const caddyFile = path.join(root, 'Caddyfile');
+    fs.writeFileSync(caddyFile, '');
+    const caddyDir = path.join(root, 'caddy-conf');
+    fs.mkdirSync(caddyDir);
+    const missing = path.join(root, 'missing');
+    const stateDir = path.join(root, 'state');
+    const homepageConfigRoot = path.join(root, 'homepage', 'config');
+    fs.mkdirSync(homepageConfigRoot, { recursive: true });
+
+    withService(
+      { suite: { DATABASE_FILENAME: 'suite.db' } },
+      ({ BackupInventoryService, HOMEPAGE_CONFIG_FILES }) => {
+        const service = new BackupInventoryService({
+          stateDir,
+          homepageConfigRoot,
+          caddyFiles: [caddyFile, caddyDir, missing],
+          store: makeStore([]),
+        });
+        const result = service.inventory();
+
+        assert.deepEqual(result.contents.caddyFiles, [
+          { exists: true, kind: 'file', path: caddyFile },
+          { exists: true, kind: 'directory', path: caddyDir },
+          { exists: false, kind: 'missing', path: missing },
+        ]);
+        assert.equal(result.contents.homepageConfig.path, homepageConfigRoot);
+        assert.deepEqual(
+          result.contents.homepageConfig.files,
+          HOMEPAGE_CONFIG_FILES.map((name) => ({
+            exists: false,
+            kind: 'missing',
+            path: path.join(homepageConfigRoot, name),
+          })),
+        );
+        assert.deepEqual(result.contents.suiteManager, {
+          appSecrets: { exists: false, kind: 'missing', path: path.join(stateDir, 'app-secrets') },
+          database: { exists: false, kind: 'missing', path: path.join(stateDir, 'suite.db') },
+          databaseShm: { exists: false, kind: 'missing', path: path.join(stateDir, 'suite.db-shm') },
+          databaseWal: { exists: false, kind: 'missing', path: path.join(stateDir, 'suite.db-wal') },
+          stateDir,
+        });
+      },
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/suite-manager/backend/test/backup-inventory-service.test.cjs
+++ b/suite-manager/backend/test/backup-inventory-service.test.cjs
@@ -5,15 +5,24 @@ const os = require('node:os');
 const path = require('node:path');
 
 const TEMP_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'backup-inventory-'));
+const STATE_DIR = path.join(TEMP_ROOT, 'state');
 const servicePath = require.resolve('../src/backups/backup-inventory-service.cjs');
 
 const { BackupInventoryService, DEFAULT_CADDY_FILES, DEFAULT_HTTPS_SECRET_PATH, HOMEPAGE_CONFIG_FILES, uniqueVolumesFor } = require(servicePath);
 const { digestAppPackage } = require('../src/apps/package-contracts.cjs');
 
+test.after(() => {
+  fs.rmSync(TEMP_ROOT, { recursive: true, force: true });
+});
+
+// Writes a real package snapshot under TEMP_ROOT and returns its true digest, so
+// the inventory exercises the real manifest reader and digest function rather
+// than a stub. Defaults cover every field manifest validation requires; anything
+// passed in overrides them, with `resources` replaced wholesale rather than
+// merged so a caller declaring services does not inherit the default service.
 function setupSnapshot(manifestObj) {
-  const snapshotPath = fs.mkdtempSync(path.join(os.tmpdir(), 'mos-snap-'));
-  
-  // Create a valid default manifest that passes all schema validation rules
+  const snapshotPath = fs.mkdtempSync(path.join(TEMP_ROOT, 'snap-'));
+
   const defaultManifest = {
     manifestVersion: 1,
     name: 'Test App',
@@ -22,19 +31,17 @@ function setupSnapshot(manifestObj) {
     category: 'utilities',
     health: { type: 'http', url: 'http://app/' },
     resources: { services: { main: { image: 'test-image' } } },
-    version: '1.0.0'
+    version: '1.0.0',
   };
-  
-  // Merge the provided manifestObj over the defaults
+
   const fullManifest = {
     ...defaultManifest,
     ...manifestObj,
-    // Deep merge resources to avoid wiping out the valid default if resources is partially specified
-    resources: manifestObj?.resources || defaultManifest.resources
+    resources: manifestObj?.resources || defaultManifest.resources,
   };
-  
+
   fs.writeFileSync(path.join(snapshotPath, 'manifest.json'), JSON.stringify(fullManifest));
-  fs.writeFileSync(path.join(snapshotPath, 'Dockerfile'), ''); // write empty dockerfile so validation passes
+  fs.writeFileSync(path.join(snapshotPath, 'Dockerfile'), ''); // an empty Dockerfile is enough for validation
   const digest = digestAppPackage(snapshotPath);
   return { snapshotPath, digest };
 }
@@ -116,18 +123,19 @@ test('uniqueVolumesFor handles manifests without services', () => {
 
 test('constructor uses MOS_STATE_ROOT when present', () => {
   const previous = process.env.MOS_STATE_ROOT;
-  process.env.MOS_STATE_ROOT = '/tmp/mos-state';
+  const configuredRoot = path.join(TEMP_ROOT, 'mos-state');
+  process.env.MOS_STATE_ROOT = configuredRoot;
   try {
-      const service = new BackupInventoryService({
-        stateDir: '/tmp/state/suite-manager',
-        store: {},
-      });
-      assert.equal(service.stateRoot, '/tmp/mos-state');
-      assert.equal(
-        service.homepageConfigRoot,
-        path.join('/tmp/mos-state', 'homepage', 'config'),
-      );
-      } finally {
+    const service = new BackupInventoryService({
+      stateDir: path.join(TEMP_ROOT, 'state', 'suite-manager'),
+      store: {},
+    });
+    assert.equal(service.stateRoot, configuredRoot);
+    assert.equal(
+      service.homepageConfigRoot,
+      path.join(configuredRoot, 'homepage', 'config'),
+    );
+  } finally {
     if (previous === undefined) delete process.env.MOS_STATE_ROOT;
     else process.env.MOS_STATE_ROOT = previous;
   }
@@ -137,12 +145,12 @@ test('constructor defaults stateRoot to parent when stateDir is suite-manager', 
   const previous = process.env.MOS_STATE_ROOT;
   delete process.env.MOS_STATE_ROOT;
   try {
-      const service = new BackupInventoryService({
-        stateDir: path.join(TEMP_ROOT, 'suite-manager'),
-        store: {},
-      });
-      assert.equal(service.stateRoot, TEMP_ROOT);
-      } finally {
+    const service = new BackupInventoryService({
+      stateDir: path.join(TEMP_ROOT, 'suite-manager'),
+      store: {},
+    });
+    assert.equal(service.stateRoot, TEMP_ROOT);
+  } finally {
     if (previous === undefined) delete process.env.MOS_STATE_ROOT;
     else process.env.MOS_STATE_ROOT = previous;
   }
@@ -152,12 +160,12 @@ test('constructor resolves stateRoot to parent for non-suite-manager state dirs'
   const previous = process.env.MOS_STATE_ROOT;
   delete process.env.MOS_STATE_ROOT;
   try {
-      const service = new BackupInventoryService({
-        stateDir: path.join(TEMP_ROOT, 'state-dir'),
-        store: {},
-      });
-      assert.equal(service.stateRoot, TEMP_ROOT);
-      } finally {
+    const service = new BackupInventoryService({
+      stateDir: path.join(TEMP_ROOT, 'state-dir'),
+      store: {},
+    });
+    assert.equal(service.stateRoot, TEMP_ROOT);
+  } finally {
     if (previous === undefined) delete process.env.MOS_STATE_ROOT;
     else process.env.MOS_STATE_ROOT = previous;
   }
@@ -170,29 +178,29 @@ test('constructor applies default caddy and secret paths', () => {
 });
 
 test('inventory summarizes an empty store', () => {
-    const service = new BackupInventoryService({
-      stateDir: '/tmp/empty-state',
-      store: makeStore([]),
-    });
-    const result = service.inventory();
-
-    assert.equal(result.summary.appCount, 0);
-    assert.equal(result.summary.declaredVolumeCount, 0);
-    assert.equal(result.summary.relationshipCount, 0);
-    assert.equal(result.summary.warningCount, 0);
-    assert.deepEqual(result.packages, []);
-    assert.deepEqual(result.warnings, []);
-    assert.deepEqual(result.relationships, { active: 0, count: 0, statuses: [] });
-    assert.deepEqual(result.packageManifestDigests, []);
-    assert.deepEqual(result.actions, {
-      backupEnabled: false,
-      backupLabel: 'Back up everything',
-      backupReason: 'MOS backup inventory is ready, but archive and restore jobs wait for a MOS backup agent.',
-      restoreEnabled: false,
-    });
-    assert.equal(typeof result.checkedAt, 'string');
-    assert.equal(Number.isNaN(Date.parse(result.checkedAt)), false);
+  const service = new BackupInventoryService({
+    stateDir: path.join(TEMP_ROOT, 'empty-state'),
+    store: makeStore([]),
   });
+  const result = service.inventory();
+
+  assert.equal(result.summary.appCount, 0);
+  assert.equal(result.summary.declaredVolumeCount, 0);
+  assert.equal(result.summary.relationshipCount, 0);
+  assert.equal(result.summary.warningCount, 0);
+  assert.deepEqual(result.packages, []);
+  assert.deepEqual(result.warnings, []);
+  assert.deepEqual(result.relationships, { active: 0, count: 0, statuses: [] });
+  assert.deepEqual(result.packageManifestDigests, []);
+  assert.deepEqual(result.actions, {
+    backupEnabled: false,
+    backupLabel: 'Back up everything',
+    backupReason: 'MOS backup inventory is ready, but archive and restore jobs wait for a MOS backup agent.',
+    restoreEnabled: false,
+  });
+  assert.equal(typeof result.checkedAt, 'string');
+  assert.equal(Number.isNaN(Date.parse(result.checkedAt)), false);
+});
 
 test('inventory reports missing snapshot warnings for uninstalled snapshot states', () => {
   const instance = makeInstance({
@@ -202,23 +210,23 @@ test('inventory reports missing snapshot warnings for uninstalled snapshot state
     snapshotPath: '/does/not/exist',
   });
 
-    const service = new BackupInventoryService({
-      stateDir: '/tmp/state',
-      store: makeStore([instance]),
-    });
-    const result = service.inventory();
-
-    assert.equal(result.packages.length, 1);
-    const pkg = result.packages[0];
-    assert.equal(pkg.manifestPresent, false);
-    assert.equal(pkg.snapshot.verified, false);
-    assert.deepEqual(pkg.declaredVolumes, []);
-    assert.deepEqual(pkg.warnings, [
-      'Installed package snapshot is missing or invalid; restore compatibility cannot be guaranteed.',
-    ]);
-    assert.equal(result.summary.warningCount, 1);
-    assert.deepEqual(result.packageManifestDigests, []);
+  const service = new BackupInventoryService({
+    stateDir: STATE_DIR,
+    store: makeStore([instance]),
   });
+  const result = service.inventory();
+
+  assert.equal(result.packages.length, 1);
+  const pkg = result.packages[0];
+  assert.equal(pkg.manifestPresent, false);
+  assert.equal(pkg.snapshot.verified, false);
+  assert.deepEqual(pkg.declaredVolumes, []);
+  assert.deepEqual(pkg.warnings, [
+    'Installed package snapshot is missing or invalid; restore compatibility cannot be guaranteed.',
+  ]);
+  assert.equal(result.summary.warningCount, 1);
+  assert.deepEqual(result.packageManifestDigests, []);
+});
 
 test('inventory treats manifest read failures as invalid snapshots', () => {
   const instance = makeInstance({
@@ -227,17 +235,17 @@ test('inventory treats manifest read failures as invalid snapshots', () => {
     snapshotPath: '/snap/app-1', // will fail to read since it doesn't exist
   });
 
-      const service = new BackupInventoryService({
-        stateDir: '/tmp/state',
-        store: makeStore([instance]),
-      });
-      const result = service.inventory();
+  const service = new BackupInventoryService({
+    stateDir: STATE_DIR,
+    store: makeStore([instance]),
+  });
+  const result = service.inventory();
 
-      assert.equal(result.packages[0].manifestPresent, false);
-      assert.equal(result.packages[0].snapshot.verified, false);
-      assert.deepEqual(result.packages[0].declaredVolumes, []);
-      assert.equal(result.summary.warningCount, 1);
-    });
+  assert.equal(result.packages[0].manifestPresent, false);
+  assert.equal(result.packages[0].snapshot.verified, false);
+  assert.deepEqual(result.packages[0].declaredVolumes, []);
+  assert.equal(result.summary.warningCount, 1);
+});
 
 test('inventory maps a verified installed package and its declared volumes', () => {
   const { snapshotPath, digest } = setupSnapshot({
@@ -255,32 +263,32 @@ test('inventory maps a verified installed package and its declared volumes', () 
     snapshotState: 'installed',
   });
 
-      const service = new BackupInventoryService({
-        stateDir: '/tmp/state',
-        store: makeStore([instance]),
-      });
-      const result = service.inventory();
+  const service = new BackupInventoryService({
+    stateDir: STATE_DIR,
+    store: makeStore([instance]),
+  });
+  const result = service.inventory();
 
-      assert.equal(result.packages.length, 1);
-      const pkg = result.packages[0];
-      assert.equal(pkg.manifestPresent, true);
-      assert.equal(pkg.snapshot.verified, true);
-      assert.deepEqual(pkg.declaredVolumes, [
-        { declaredName: 'data', dockerVolume: 'mos-app-app-1-data', backupClass: 'data', requiredOnRestore: true },
-      ]);
-      assert.deepEqual(pkg.warnings, [
-        'Package declares volumes but no explicit backup metadata yet.',
-      ]);
-      assert.equal(result.summary.declaredVolumeCount, 1);
-      assert.equal(result.summary.warningCount, 1);
-      assert.deepEqual(result.packageManifestDigests, [
-        { digest: 'manifest-digest-1', packageId: 'app-1', version: '1.0.0' },
-      ]);
-    });
+  assert.equal(result.packages.length, 1);
+  const pkg = result.packages[0];
+  assert.equal(pkg.manifestPresent, true);
+  assert.equal(pkg.snapshot.verified, true);
+  assert.deepEqual(pkg.declaredVolumes, [
+    { declaredName: 'data', dockerVolume: 'mos-app-app-1-data', backupClass: 'data', requiredOnRestore: true },
+  ]);
+  assert.deepEqual(pkg.warnings, [
+    'Package declares volumes but no explicit backup metadata yet.',
+  ]);
+  assert.equal(result.summary.declaredVolumeCount, 1);
+  assert.equal(result.summary.warningCount, 1);
+  assert.deepEqual(result.packageManifestDigests, [
+    { digest: 'manifest-digest-1', packageId: 'app-1', version: '1.0.0' },
+  ]);
+});
 
 test('inventory marks snapshot unverified when manifest id does not match package id', () => {
   const { snapshotPath, digest } = setupSnapshot({ id: 'app-2', resources: { services: { app: { dockerfile: 'Dockerfile', internalPort: 8080 } } } });
-  
+
   const instance = makeInstance({
     packageId: 'app-1',
     packageDigest: digest,
@@ -288,23 +296,23 @@ test('inventory marks snapshot unverified when manifest id does not match packag
     snapshotPath,
   });
 
-      const service = new BackupInventoryService({
-        stateDir: '/tmp/state',
-        store: makeStore([instance]),
-      });
-      const pkg = service.inventory().packages[0];
+  const service = new BackupInventoryService({
+    stateDir: STATE_DIR,
+    store: makeStore([instance]),
+  });
+  const pkg = service.inventory().packages[0];
 
-      assert.equal(pkg.manifestPresent, true);
-      assert.equal(pkg.snapshot.verified, false);
-      assert.deepEqual(pkg.declaredVolumes, []);
-      assert.deepEqual(pkg.warnings, [
-        'Installed package snapshot is missing or invalid; restore compatibility cannot be guaranteed.',
-      ]);
-    });
+  assert.equal(pkg.manifestPresent, true);
+  assert.equal(pkg.snapshot.verified, false);
+  assert.deepEqual(pkg.declaredVolumes, []);
+  assert.deepEqual(pkg.warnings, [
+    'Installed package snapshot is missing or invalid; restore compatibility cannot be guaranteed.',
+  ]);
+});
 
 test('inventory marks snapshot unverified when package digest does not match', () => {
-  const { snapshotPath, digest } = setupSnapshot({ id: 'app-1', resources: { services: { app: { dockerfile: 'Dockerfile', internalPort: 8080 } } } });
-  
+  const { snapshotPath } = setupSnapshot({ id: 'app-1', resources: { services: { app: { dockerfile: 'Dockerfile', internalPort: 8080 } } } });
+
   const instance = makeInstance({
     packageId: 'app-1',
     packageDigest: 'wrong-digest',
@@ -312,18 +320,18 @@ test('inventory marks snapshot unverified when package digest does not match', (
     snapshotPath,
   });
 
-      const service = new BackupInventoryService({
-        stateDir: '/tmp/state',
-        store: makeStore([instance]),
-      });
-      const pkg = service.inventory().packages[0];
+  const service = new BackupInventoryService({
+    stateDir: STATE_DIR,
+    store: makeStore([instance]),
+  });
+  const pkg = service.inventory().packages[0];
 
-      assert.equal(pkg.manifestPresent, true);
-      assert.equal(pkg.snapshot.verified, false);
-      assert.deepEqual(pkg.warnings, [
-        'Installed package snapshot is missing or invalid; restore compatibility cannot be guaranteed.',
-      ]);
-    });
+  assert.equal(pkg.manifestPresent, true);
+  assert.equal(pkg.snapshot.verified, false);
+  assert.deepEqual(pkg.warnings, [
+    'Installed package snapshot is missing or invalid; restore compatibility cannot be guaranteed.',
+  ]);
+});
 
 test('inventory aggregates relationship statuses', () => {
   const relationships = [
@@ -332,65 +340,61 @@ test('inventory aggregates relationship statuses', () => {
     { status: 'disabled' },
   ];
 
-    const service = new BackupInventoryService({
-      stateDir: '/tmp/state',
-      store: makeStore([], relationships),
-    });
-    const result = service.inventory();
-
-    assert.deepEqual(result.relationships, {
-      active: 2,
-      count: 3,
-      statuses: [
-        { count: 2, status: 'active' },
-        { count: 1, status: 'disabled' },
-      ],
-    });
-    assert.equal(result.summary.relationshipCount, 3);
+  const service = new BackupInventoryService({
+    stateDir: STATE_DIR,
+    store: makeStore([], relationships),
   });
+  const result = service.inventory();
+
+  assert.deepEqual(result.relationships, {
+    active: 2,
+    count: 3,
+    statuses: [
+      { count: 2, status: 'active' },
+      { count: 1, status: 'disabled' },
+    ],
+  });
+  assert.equal(result.summary.relationshipCount, 3);
+});
 
 test('inventory reports filesystem path states for contents', () => {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'backup-inventory-'));
-  try {
-    const caddyFile = path.join(root, 'Caddyfile');
-    fs.writeFileSync(caddyFile, '');
-    const caddyDir = path.join(root, 'caddy-conf');
-    fs.mkdirSync(caddyDir);
-    const missing = path.join(root, 'missing');
-    const stateDir = path.join(root, 'state');
-    const homepageConfigRoot = path.join(root, 'homepage', 'config');
-    fs.mkdirSync(homepageConfigRoot, { recursive: true });
+  const root = fs.mkdtempSync(path.join(TEMP_ROOT, 'contents-'));
+  const caddyFile = path.join(root, 'Caddyfile');
+  fs.writeFileSync(caddyFile, '');
+  const caddyDir = path.join(root, 'caddy-conf');
+  fs.mkdirSync(caddyDir);
+  const missing = path.join(root, 'missing');
+  const stateDir = path.join(root, 'state');
+  const homepageConfigRoot = path.join(root, 'homepage', 'config');
+  fs.mkdirSync(homepageConfigRoot, { recursive: true });
 
-        const service = new BackupInventoryService({
-          stateDir,
-          homepageConfigRoot,
-          caddyFiles: [caddyFile, caddyDir, missing],
-          store: makeStore([]),
-        });
-        const result = service.inventory();
+  const service = new BackupInventoryService({
+    stateDir,
+    homepageConfigRoot,
+    caddyFiles: [caddyFile, caddyDir, missing],
+    store: makeStore([]),
+  });
+  const result = service.inventory();
 
-        assert.deepEqual(result.contents.caddyFiles, [
-          { exists: true, kind: 'file', path: caddyFile },
-          { exists: true, kind: 'directory', path: caddyDir },
-          { exists: false, kind: 'missing', path: missing },
-        ]);
-        assert.equal(result.contents.homepageConfig.path, homepageConfigRoot);
-        assert.deepEqual(
-          result.contents.homepageConfig.files,
-          HOMEPAGE_CONFIG_FILES.map((name) => ({
-            exists: false,
-            kind: 'missing',
-            path: path.join(homepageConfigRoot, name),
-          })),
-        );
-        assert.deepEqual(result.contents.suiteManager, {
-          appSecrets: { exists: false, kind: 'missing', path: path.join(stateDir, 'app-secrets') },
-          database: { exists: false, kind: 'missing', path: path.join(stateDir, 'suite-manager.sqlite') },
-          databaseShm: { exists: false, kind: 'missing', path: path.join(stateDir, 'suite-manager.sqlite-shm') },
-          databaseWal: { exists: false, kind: 'missing', path: path.join(stateDir, 'suite-manager.sqlite-wal') },
-          stateDir,
-        });
-        } finally {
-    fs.rmSync(root, { recursive: true, force: true });
-  }
+  assert.deepEqual(result.contents.caddyFiles, [
+    { exists: true, kind: 'file', path: caddyFile },
+    { exists: true, kind: 'directory', path: caddyDir },
+    { exists: false, kind: 'missing', path: missing },
+  ]);
+  assert.equal(result.contents.homepageConfig.path, homepageConfigRoot);
+  assert.deepEqual(
+    result.contents.homepageConfig.files,
+    HOMEPAGE_CONFIG_FILES.map((name) => ({
+      exists: false,
+      kind: 'missing',
+      path: path.join(homepageConfigRoot, name),
+    })),
+  );
+  assert.deepEqual(result.contents.suiteManager, {
+    appSecrets: { exists: false, kind: 'missing', path: path.join(stateDir, 'app-secrets') },
+    database: { exists: false, kind: 'missing', path: path.join(stateDir, 'suite-manager.sqlite') },
+    databaseShm: { exists: false, kind: 'missing', path: path.join(stateDir, 'suite-manager.sqlite-shm') },
+    databaseWal: { exists: false, kind: 'missing', path: path.join(stateDir, 'suite-manager.sqlite-wal') },
+    stateDir,
+  });
 });

--- a/suite-manager/backend/test/https-settings-service.test.cjs
+++ b/suite-manager/backend/test/https-settings-service.test.cjs
@@ -1,49 +1,442 @@
-// The host gate is what turns the Easy Door from a name that resolves into a
-// name the machine answers on: DNS already points a browser here, and Suite
-// Manager returns 421 for every host it does not recognise.
+'use strict';
 
 const assert = require('node:assert/strict');
-const test = require('node:test');
+const path = require('node:path');
+const { test } = require('node:test');
 
-const { HttpsSettingsService } = require('../src/settings/https-settings-service.cjs');
+const targetPath = require.resolve('../src/settings/https-settings-service.cjs');
+const target = require(targetPath);
+const sharedDir = path.resolve(path.dirname(targetPath), '../../../../shared');
+const { HttpsSettingsError } = require(path.join(sharedDir, 'https-contract.cjs'));
+const { easyDoorHomeHost } = require(path.join(sharedDir, 'easy-door.cjs'));
 
-function service({ address = '192.168.123.45', settings = {} } = {}) {
-  return new HttpsSettingsService({
-    agent: {},
-    bootstrapHost: 'home.mos.home',
-    detectAddress: () => address,
-    store: {
-      getHttpsSettings: () => ({ baseDomain: null, pendingBaseDomain: null, tlsMode: 'none', ...settings }),
-    },
-  });
+const {
+  HttpsSettingsService,
+  homeHostFor,
+  privateHttpsAvailable,
+  publicStatus,
+} = target;
+
+function validHttpsInput() {
+  return {
+    acmeEmail: 'ops@example.com',
+    baseDomain: 'example.com',
+    cloudflareApiToken: 'test-token-not-real-abcdefghijklmnopqrst',
+  };
 }
 
-test('a private LAN address answers on its Easy Door name as well as the Stealth one', () => {
-  const hosts = service().allowedHosts();
+function makeStore(settings = {}) {
+  const calls = { begin: [], complete: [], fail: [] };
+  const baseSettings = {
+    acmeEmail: 'ops@example.com',
+    baseDomain: 'example.com',
+    lastApplyAt: null,
+    lastApplyDiagnostics: null,
+    lastApplyErrorCode: null,
+    lastApplyStatus: null,
+    provider: 'digitalocean',
+    tlsMode: 'cloudflare-dns01',
+    ...settings,
+  };
 
-  assert.equal(hosts.has('home.192-168-123-45.local.myownsuite.org'), true);
-  assert.equal(hosts.has('home.mos.home'), true);
+  return {
+    calls,
+    store: {
+      getHttpsSettings: () => ({ ...baseSettings }),
+      beginHttpsApply: (arg) => calls.begin.push(arg),
+      completeHttpsApply: (arg) => calls.complete.push(arg),
+      failHttpsApply: (arg) => calls.fail.push(arg),
+    },
+  };
+}
+
+function makeAgent(applyResult = { rollbackId: 'rollback-42' }) {
+  const calls = { apply: [], rollback: [], commit: [] };
+
+  return {
+    calls,
+    agent: {
+      apply: async (arg) => {
+        calls.apply.push(arg);
+        return applyResult;
+      },
+      rollback: async (arg) => calls.rollback.push(arg),
+      commit: async (arg) => calls.commit.push(arg),
+    },
+  };
+}
+
+function makeNow(isoValues) {
+  let index = 0;
+  return () => {
+    const iso = isoValues[index] ?? isoValues[isoValues.length - 1];
+    if (index < isoValues.length - 1) index += 1;
+    return new Date(iso);
+  };
+}
+
+test('homeHostFor returns a home subdomain or null', () => {
+  assert.equal(homeHostFor('example.com'), 'home.example.com');
+  assert.equal(homeHostFor(''), null);
+  assert.equal(homeHostFor(null), null);
+  assert.equal(homeHostFor(undefined), null);
 });
 
-test('a public address gets no Easy Door name, which is what keeps cloud installs out', () => {
-  assert.deepEqual([...service({ address: '203.0.113.10' }).allowedHosts()], ['home.mos.home']);
-  assert.deepEqual([...service({ address: null }).allowedHosts()], ['home.mos.home']);
+test('privateHttpsAvailable blocks cloud-init and digitalocean-smoke front doors', () => {
+  assert.equal(privateHttpsAvailable('ssh-bootstrap'), true);
+  assert.equal(privateHttpsAvailable('other'), true);
+  assert.equal(privateHttpsAvailable('cloud-init'), false);
+  assert.equal(privateHttpsAvailable('digitalocean-smoke'), false);
 });
 
-test('applying a real domain with DNS-01 closes the Easy Door name for good', () => {
-  const hosts = service({
-    settings: { baseDomain: 'mos.example.com', tlsMode: 'cloudflare-dns01' },
-  }).allowedHosts();
+test('publicStatus builds the HTTPS settings status payload', () => {
+  const settings = {
+    acmeEmail: 'ops@example.com',
+    baseDomain: 'example.com',
+    lastApplyAt: '2024-01-01T00:00:00.000Z',
+    lastApplyDiagnostics: 'service became stable',
+    lastApplyErrorCode: 'HTTPS_APPLY_FAILED',
+    lastApplyStatus: 'failed',
+    provider: 'digitalocean',
+    tlsMode: 'cloudflare-dns01',
+  };
 
-  assert.deepEqual([...hosts], ['home.mos.home', 'home.mos.example.com']);
-  assert.equal(hosts.has('home.192-168-123-45.local.myownsuite.org'), false);
+  const status = publicStatus(settings, 'bootstrap.test', true, {
+    frontDoor: 'ssh-bootstrap',
+    serverAddress: '10.0.0.20',
+  });
+
+  assert.deepEqual(status, {
+    acmeEmail: 'ops@example.com',
+    activeHomeUrl: 'https://home.example.com/',
+    agentAvailable: true,
+    baseDomain: 'example.com',
+    bootstrapUrl: 'http://bootstrap.test/',
+    lastApply: {
+      at: '2024-01-01T00:00:00.000Z',
+      diagnostics: 'service became stable',
+      errorCode: 'HTTPS_APPLY_FAILED',
+      status: 'failed',
+    },
+    installContext: 'ssh-bootstrap',
+    privateHttpsAvailable: true,
+    provider: 'digitalocean',
+    serverAddress: '10.0.0.20',
+    tlsMode: 'cloudflare-dns01',
+    tokenConfigured: true,
+  });
 });
 
-test('a domain waiting to be applied is still reachable alongside the Easy Door', () => {
-  const hosts = service({ settings: { pendingBaseDomain: 'mos.example.com' } }).allowedHosts();
-
-  assert.deepEqual(
-    [...hosts],
-    ['home.mos.home', 'home.mos.example.com', 'home.192-168-123-45.local.myownsuite.org'],
+test('publicStatus falls back to bootstrap HTTP URL when no base domain exists', () => {
+  const status = publicStatus(
+    {
+      acmeEmail: null,
+      baseDomain: null,
+      lastApplyAt: null,
+      lastApplyDiagnostics: null,
+      lastApplyErrorCode: null,
+      lastApplyStatus: null,
+      provider: null,
+      tlsMode: 'http',
+    },
+    'bootstrap.test',
+    false,
+    { frontDoor: 'digitalocean-smoke', serverAddress: '10.0.0.21' },
   );
+
+  assert.equal(status.activeHomeUrl, 'http://bootstrap.test/');
+  assert.equal(status.bootstrapUrl, 'http://bootstrap.test/');
+  assert.equal(status.privateHttpsAvailable, false);
+  assert.equal(status.tokenConfigured, false);
+});
+
+test('easyDoorHost returns null for cloudflare-dns01 TLS mode', () => {
+  const settings = { tlsMode: 'cloudflare-dns01' };
+
+  const service = new HttpsSettingsService({
+    agent: {},
+    bootstrapHost: 'bootstrap.test',
+    store: { getHttpsSettings: () => settings },
+  });
+
+  assert.equal(service.easyDoorHost(settings), null);
+});
+
+test('easyDoorHost is derived from the current detected address for non-cloudflare modes', () => {
+  const detectAddress = () => '10.0.1.30';
+
+  const service = new HttpsSettingsService({
+    agent: {},
+    bootstrapHost: 'bootstrap.test',
+    detectAddress,
+    store: { getHttpsSettings: () => ({ tlsMode: 'http' }) },
+  });
+
+  assert.equal(
+    service.easyDoorHost({ tlsMode: 'http' }),
+    easyDoorHomeHost('10.0.1.30'),
+  );
+});
+
+test('allowedHosts includes bootstrap, active home, pending home, and easy door hosts', () => {
+  const detectAddress = () => '10.0.1.40';
+  const settings = {
+    baseDomain: 'example.com',
+    pendingBaseDomain: 'pending.example.com',
+    tlsMode: 'http',
+  };
+
+  const service = new HttpsSettingsService({
+    agent: {},
+    bootstrapHost: 'bootstrap.test',
+    detectAddress,
+    store: { getHttpsSettings: () => settings },
+  });
+
+  const expected = [
+    'bootstrap.test',
+    homeHostFor('example.com'),
+    homeHostFor('pending.example.com'),
+    easyDoorHomeHost('10.0.1.40'),
+  ].filter(Boolean);
+
+  assert.deepEqual([...service.allowedHosts()].sort(), expected.sort());
+});
+
+test('publicUrlSchemeForHost uses HTTPS only for the cloudflare home host', () => {
+  const { store } = makeStore({ baseDomain: 'example.com', tlsMode: 'cloudflare-dns01' });
+
+  const service = new HttpsSettingsService({
+    agent: {},
+    bootstrapHost: 'bootstrap.test',
+    store,
+  });
+
+  assert.equal(service.publicUrlSchemeForHost('home.example.com'), 'https');
+  assert.equal(service.publicUrlSchemeForHost(' HOME.Example.COM '), 'https');
+  assert.equal(service.publicUrlSchemeForHost('www.example.com'), 'http');
+  assert.equal(service.publicUrlSchemeForHost('www.example.com', 'https'), 'https');
+});
+
+test('status reports cloudflare-dns01 apply capability from agent', async () => {
+  const { store } = makeStore({ baseDomain: 'example.com', tlsMode: 'cloudflare-dns01' });
+
+  const service = new HttpsSettingsService({
+    agent: { status: async () => ({ capabilities: ['cloudflare-dns01.apply'] }) },
+    bootstrapHost: 'bootstrap.test',
+    frontDoor: 'ssh-bootstrap',
+    store,
+  });
+
+  const status = await service.status();
+
+  assert.equal(status.agentAvailable, true);
+  assert.equal(status.activeHomeUrl, 'https://home.example.com/');
+  assert.equal(status.installContext, 'ssh-bootstrap');
+  assert.equal(status.privateHttpsAvailable, true);
+  assert.equal(status.tokenConfigured, true);
+  assert.equal(typeof status.serverAddress, 'string');
+});
+
+test('status reports agent unavailable when agent.status throws', async () => {
+  const { store } = makeStore({ baseDomain: null, tlsMode: 'http' });
+
+  const service = new HttpsSettingsService({
+    agent: { status: async () => { throw new Error('agent down'); } },
+    bootstrapHost: 'bootstrap.test',
+    frontDoor: 'ssh-bootstrap',
+    store,
+  });
+
+  const status = await service.status();
+
+  assert.equal(status.agentAvailable, false);
+  assert.equal(status.activeHomeUrl, 'http://bootstrap.test/');
+});
+
+test('apply begins, completes, commits, and returns the new HTTPS URLs', async () => {
+  const { store, calls: storeCalls } = makeStore();
+  const { agent, calls: agentCalls } = makeAgent({ rollbackId: 'rollback-42' });
+  const now = makeNow([
+    '2024-01-01T00:00:00.000Z',
+    '2024-01-01T00:01:00.000Z',
+  ]);
+
+  const service = new HttpsSettingsService({
+    agent,
+    bootstrapHost: 'bootstrap.test',
+    frontDoor: 'ssh-bootstrap',
+    now,
+    store,
+  });
+
+  const result = await service.apply(validHttpsInput());
+
+  assert.deepEqual(result, {
+    appliedAt: '2024-01-01T00:01:00.000Z',
+    bootstrapUrl: 'http://bootstrap.test/',
+    homeUrl: 'https://home.example.com/',
+    status: 'applied',
+  });
+
+  assert.equal(storeCalls.begin.length, 1);
+  assert.equal(storeCalls.begin[0].acmeEmail, 'ops@example.com');
+  assert.equal(storeCalls.begin[0].baseDomain, 'example.com');
+  assert.equal(storeCalls.begin[0].at, '2024-01-01T00:00:00.000Z');
+
+  assert.deepEqual(storeCalls.complete, ['2024-01-01T00:01:00.000Z']);
+
+  assert.equal(agentCalls.apply.length, 1);
+  assert.equal(agentCalls.apply[0].acmeEmail, 'ops@example.com');
+  assert.equal(agentCalls.apply[0].baseDomain, 'example.com');
+  assert.equal(agentCalls.apply[0].bootstrapHost, 'bootstrap.test');
+  assert.equal(agentCalls.apply[0].cloudflareApiToken, 'test-token-not-real-abcdefghijklmnopqrst');
+
+  assert.deepEqual(agentCalls.commit, ['rollback-42']);
+  assert.deepEqual(agentCalls.rollback, []);
+  assert.deepEqual(storeCalls.fail, []);
+});
+
+test('apply refuses private HTTPS for cloud-init and digitalocean-smoke front doors', async () => {
+  for (const frontDoor of ['cloud-init', 'digitalocean-smoke']) {
+    const { store } = makeStore();
+
+    const service = new HttpsSettingsService({
+      agent: {},
+      bootstrapHost: 'bootstrap.test',
+      frontDoor,
+      store,
+    });
+
+    await assert.rejects(
+      service.apply(validHttpsInput()),
+      (error) =>
+        error instanceof HttpsSettingsError &&
+        error.code === 'PRIVATE_HTTPS_UNAVAILABLE' &&
+        error.statusCode === 409,
+    );
+  }
+});
+
+test('apply rejects payloads that do not only include the three required keys', async () => {
+  const { store } = makeStore();
+
+  const service = new HttpsSettingsService({
+    agent: {},
+    bootstrapHost: 'bootstrap.test',
+    frontDoor: 'ssh-bootstrap',
+    store,
+  });
+
+  await assert.rejects(
+    service.apply({ acmeEmail: 'ops@example.com', baseDomain: 'example.com' }),
+    (error) =>
+      error instanceof HttpsSettingsError &&
+      error.code === 'INVALID_HTTPS_REQUEST' &&
+      error.message === 'Only the required HTTPS settings are accepted.',
+  );
+
+  await assert.rejects(
+    service.apply({
+      acmeEmail: 'ops@example.com',
+      baseDomain: 'example.com',
+      cloudflareApiToken: 'token',
+      extra: true,
+    }),
+    (error) =>
+      error instanceof HttpsSettingsError &&
+      error.code === 'INVALID_HTTPS_REQUEST',
+  );
+
+  await assert.rejects(
+    service.apply(null),
+    (error) =>
+      error instanceof HttpsSettingsError &&
+      error.code === 'INVALID_HTTPS_REQUEST',
+  );
+});
+
+test('apply records failure and throws HTTPS_APPLY_FAILED when the agent fails', async () => {
+  const { store, calls: storeCalls } = makeStore();
+  const { agent, calls: agentCalls } = makeAgent();
+
+  agent.apply = async () => {
+    throw new Error('agent unavailable');
+  };
+
+  const service = new HttpsSettingsService({
+    agent,
+    bootstrapHost: 'bootstrap.test',
+    frontDoor: 'ssh-bootstrap',
+    now: () => new Date('2024-01-01T00:00:00.000Z'),
+    store,
+  });
+
+  await assert.rejects(
+    service.apply(validHttpsInput()),
+    (error) => error.code === 'HTTPS_APPLY_FAILED' && error.statusCode === 502,
+  );
+
+  assert.equal(storeCalls.begin.length, 1);
+  assert.equal(storeCalls.fail.length, 1);
+  assert.equal(storeCalls.fail[0].errorCode, 'HTTPS_APPLY_FAILED');
+  assert.equal(agentCalls.rollback.length, 0);
+});
+
+test('apply treats an agent response without a rollback id as a failure', async () => {
+  const { store, calls: storeCalls } = makeStore();
+  const { agent, calls: agentCalls } = makeAgent({ rollbackId: null });
+
+  const service = new HttpsSettingsService({
+    agent,
+    bootstrapHost: 'bootstrap.test',
+    frontDoor: 'ssh-bootstrap',
+    now: () => new Date('2024-01-01T00:00:00.000Z'),
+    store,
+  });
+
+  await assert.rejects(
+    service.apply(validHttpsInput()),
+    (error) => error.code === 'HTTPS_APPLY_FAILED' && error.statusCode === 502,
+  );
+
+  assert.equal(agentCalls.apply.length, 1);
+  assert.equal(agentCalls.rollback.length, 0);
+  assert.equal(storeCalls.complete.length, 0);
+  assert.equal(storeCalls.fail.length, 1);
+  assert.equal(storeCalls.fail[0].errorCode, 'HTTPS_APPLY_FAILED');
+});
+
+test('apply rolls back and masks a store completion failure as HTTPS_APPLY_FAILED', async () => {
+  const { store, calls: storeCalls } = makeStore();
+  const { agent, calls: agentCalls } = makeAgent({ rollbackId: 'rollback-42' });
+
+  store.completeHttpsApply = () => {
+    storeCalls.complete.push('called');
+    throw new Error('store write failed');
+  };
+
+  const now = makeNow([
+    '2024-01-01T00:00:00.000Z',
+    '2024-01-01T00:01:00.000Z',
+  ]);
+
+  const service = new HttpsSettingsService({
+    agent,
+    bootstrapHost: 'bootstrap.test',
+    frontDoor: 'ssh-bootstrap',
+    now,
+    store,
+  });
+
+  await assert.rejects(
+    service.apply(validHttpsInput()),
+    (error) => error.code === 'HTTPS_APPLY_FAILED',
+  );
+
+  assert.deepEqual(agentCalls.rollback, ['rollback-42']);
+  assert.deepEqual(agentCalls.commit, []);
+  assert.equal(storeCalls.complete.length, 1);
+  assert.equal(storeCalls.fail.length, 1);
+  assert.equal(storeCalls.fail[0].errorCode, 'HTTPS_APPLY_FAILED');
 });

--- a/suite-manager/backend/test/https-settings-service.test.cjs
+++ b/suite-manager/backend/test/https-settings-service.test.cjs
@@ -440,3 +440,44 @@ test('apply rolls back and masks a store completion failure as HTTPS_APPLY_FAILE
   assert.equal(storeCalls.fail.length, 1);
   assert.equal(storeCalls.fail[0].errorCode, 'HTTPS_APPLY_FAILED');
 });
+
+function testService({ address = '192.168.123.45', settings = {} } = {}) {
+  return new HttpsSettingsService({
+    agent: {},
+    bootstrapHost: 'home.mos.home',
+    detectAddress: () => address,
+    store: {
+      getHttpsSettings: () => ({ baseDomain: null, pendingBaseDomain: null, tlsMode: 'none', ...settings }),
+    },
+  });
+}
+
+test('a private LAN address answers on its Easy Door name as well as the Stealth one', () => {
+  const hosts = testService().allowedHosts();
+
+  assert.equal(hosts.has('home.192-168-123-45.local.myownsuite.org'), true);
+  assert.equal(hosts.has('home.mos.home'), true);
+});
+
+test('a public address gets no Easy Door name, which is what keeps cloud installs out', () => {
+  assert.deepEqual([...testService({ address: '203.0.113.10' }).allowedHosts()], ['home.mos.home']);
+  assert.deepEqual([...testService({ address: null }).allowedHosts()], ['home.mos.home']);
+});
+
+test('applying a real domain with DNS-01 closes the Easy Door name for good', () => {
+  const hosts = testService({
+    settings: { baseDomain: 'mos.example.com', tlsMode: 'cloudflare-dns01' },
+  }).allowedHosts();
+
+  assert.deepEqual([...hosts], ['home.mos.home', 'home.mos.example.com']);
+  assert.equal(hosts.has('home.192-168-123-45.local.myownsuite.org'), false);
+});
+
+test('a domain waiting to be applied is still reachable alongside the Easy Door', () => {
+  const hosts = testService({ settings: { pendingBaseDomain: 'mos.example.com' } }).allowedHosts();
+
+  assert.deepEqual(
+    [...hosts],
+    ['home.mos.home', 'home.mos.example.com', 'home.192-168-123-45.local.myownsuite.org'],
+  );
+});

--- a/suite-manager/backend/test/https-settings-service.test.cjs
+++ b/suite-manager/backend/test/https-settings-service.test.cjs
@@ -8,7 +8,6 @@ const targetPath = require.resolve('../src/settings/https-settings-service.cjs')
 const target = require(targetPath);
 const sharedDir = path.resolve(path.dirname(targetPath), '../../../../shared');
 const { HttpsSettingsError } = require(path.join(sharedDir, 'https-contract.cjs'));
-const { easyDoorHomeHost } = require(path.join(sharedDir, 'easy-door.cjs'));
 
 const {
   HttpsSettingsService,
@@ -174,7 +173,7 @@ test('easyDoorHost is derived from the current detected address for non-cloudfla
 
   assert.equal(
     service.easyDoorHost({ tlsMode: 'http' }),
-    easyDoorHomeHost('10.0.1.30'),
+    'home.10-0-1-30.local.myownsuite.org',
   );
 });
 
@@ -195,10 +194,10 @@ test('allowedHosts includes bootstrap, active home, pending home, and easy door 
 
   const expected = [
     'bootstrap.test',
-    homeHostFor('example.com'),
-    homeHostFor('pending.example.com'),
-    easyDoorHomeHost('10.0.1.40'),
-  ].filter(Boolean);
+    'home.example.com',
+    'home.pending.example.com',
+    'home.10-0-1-40.local.myownsuite.org',
+  ];
 
   assert.deepEqual([...service.allowedHosts()].sort(), expected.sort());
 });


### PR DESCRIPTION
Adds comprehensive `node:test` unit tests for `HttpsSettingsService` (#229) and `BackupInventoryService` (#230). These test suites were generated fully autonomously using the open-source AI Test CLI to ensure they mimic the existing codebase style and framework perfectly without introducing any new dependencies.